### PR TITLE
Remove test files from .gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    elm-rails (0.2.0)
+    elm-rails (0.2.1)
       elm-compiler (~> 0.1.2)
       rails (>= 4.0)
 

--- a/elm-rails.gemspec
+++ b/elm-rails.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", ">= 4.0"
   s.add_dependency "elm-compiler", "~> 0.1.2"

--- a/lib/elm/rails/version.rb
+++ b/lib/elm/rails/version.rb
@@ -1,5 +1,5 @@
 module Elm
   module Rails
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
The tests now include two whole Rails applications, which has increased
the size of the packaged gem from 6kb to 1Mb. There is an open issue
on RubyGems to remove declared test_files from the packaged gem, but in
the meantime there does not appear to be any benefit in specifying them.