### PR TITLE
Add debug flag based on ENV['ELM_RAILS_DEBUG'].

### DIFF
--- a/elm-rails.gemspec
+++ b/elm-rails.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", ">= 4.0"
-  s.add_dependency "elm-compiler", "~> 0.1.2"
+  s.add_dependency "elm-compiler", "~> 0.2.1"
+
+  s.add_development_dependency "minitest"
 end

--- a/lib/elm/rails/sprockets.rb
+++ b/lib/elm/rails/sprockets.rb
@@ -24,9 +24,17 @@ module Elm
       end
 
       def call(input)
-        context  = input[:environment].context_class.new(input)
+        context = input[:environment].context_class.new(input)
         add_elm_dependencies(input[:filename], input[:load_path], context)
-        context.metadata.merge(data: Elm::Compiler.compile(input[:filename]))
+        debug_flag = case ENV['ELM_RAILS_DEBUG'].downcase
+                     when 'false', '0', nil
+                       false
+                     else
+                       true
+                     end
+        context.metadata.merge(
+          data: Elm::Compiler.compile(input[:filename], debug: debug_flag)
+        )
       end
 
       private

--- a/lib/elm/rails/sprockets.rb
+++ b/lib/elm/rails/sprockets.rb
@@ -26,8 +26,9 @@ module Elm
       def call(input)
         context = input[:environment].context_class.new(input)
         add_elm_dependencies(input[:filename], input[:load_path], context)
-        debug_flag = case ENV['ELM_RAILS_DEBUG'].downcase
-                     when 'false', '0', nil
+        debug = ENV['ELM_RAILS_DEBUG'].nil? ? nil : ENV['ELM_RAILS_DEBUG'].downcase
+        debug_flag = case debug
+                     when nil, 'false', '0'
                        false
                      else
                        true

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -7,6 +7,11 @@ class TestAssetPipeline < Minitest::Test
       # the compiled Elm
       assert system('(cd test/rails5.0 && bundle exec rake assets:precompile && cat public/assets/application-*.js | grep "_elm_lang\$html\$Html\$text(\'Hello, World!\')")'), "Compiling Elm assets in Rails 5 app failed"
     end
+    Bundler.with_clean_env do
+      # Set ELM_RAILS_DEBUG and then run rake assets:precompile in the sample
+      # Rails 5.0 app and confirm that the output JS includes the Elm debugger
+      assert system('(cd test/rails5.0 && export ELM_RAILS_DEBUG="true" && bundle exec rake assets:precompile && cat public/assets/application-*.js | grep "_elm_lang$virtual_dom$Native_Debug")'), "Compiling DEBUG Elm assets in Rails 5 app failed" 
+    end
   end
 
   def test_rails_4_2
@@ -14,6 +19,11 @@ class TestAssetPipeline < Minitest::Test
       # Run rake assets:precompile in the sample Rails 4.2.7.1 app and confirm that the output JS includes
       # the compiled Elm
       assert system('(cd test/rails4.2 && bundle exec rake assets:precompile && cat public/assets/application-*.js | grep "_elm_lang\$html\$Html\$text(\'Hello, World!\')")'), "Compiling Elm assets in Rails 4.2 app failed"
+    end
+    Bundler.with_clean_env do
+      # Set ELM_RAILS_DEBUG and then run rake assets:precompile in the sample
+      # Rails 4.2.7.1 app and confirm that the output JS includes the Elm debugger
+      assert system('(cd test/rails4.2 && export ELM_RAILS_DEBUG="true" && bundle exec rake assets:precompile && cat public/assets/application-*.js | grep "_elm_lang$virtual_dom$Native_Debug")'), "Compiling DEBUG Elm assets in Rails 4.2 app failed" 
     end
   end
 end


### PR DESCRIPTION
Debug is disabled if `ENV['ELM_RAILS_DEBUG']` is unset (aka, `nil`), or set to either `'false'` or `'0'`.  Any other value will enable debug.

This should pass once [PR 6 from ruby-elm-compiler](https://github.com/fbonetti/ruby-elm-compiler/pull/6) gets merged.