### PR TITLE
Bump elm-compiler and expose elm_make_path configuration option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ install:
   - bundle install --gemfile=test/rails4.2/Gemfile
   - bundle install --gemfile=test/rails5.0/Gemfile
   - npm install -g elm
-cache:
-  directories:
-    - test/rails5.0/elm-stuff/build-artifacts
-    - test/rails4.2/elm-stuff/build-artifacts
 rvm:
   - 2.3.3
   - 2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     elm-rails (0.2.1)
-      elm-compiler (~> 0.1.2)
+      elm-compiler (>= 0.2.0)
       rails (>= 4.0)
 
 GEM
@@ -46,13 +46,13 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
-    builder (3.2.2)
+    builder (3.2.3)
     concurrent-ruby (1.0.4)
-    elm-compiler (0.1.2)
+    elm-compiler (0.2.1)
     erubis (2.7.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    i18n (0.7.0)
+    i18n (0.8.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -104,7 +104,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
 
@@ -115,4 +115,4 @@ DEPENDENCIES
   elm-rails!
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/README.md
+++ b/README.md
@@ -58,5 +58,9 @@ This gem is tested against Ruby 2.2 and 2.3, and Rails versions 4.2.7 and 5.0. I
 
 ## Configuration
 
-There is nothing to configure, but you should have Elm installed in your system
-and `elm-make` must be availble in your path.
+By default, elm-rails will use the version of `elm-make` available in your system path. If you wish, you may configure this in an initializer:
+    **config/initializers/elm_rails.rb**
+    ```erb
+    Elm::Rails.elm_make_path = "bin/elm-make"
+    ```
+

--- a/elm-rails.gemspec
+++ b/elm-rails.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", ">= 4.0"
-  s.add_dependency "elm-compiler", "~> 0.1.2"
+  s.add_dependency "elm-compiler", ">= 0.2.0"
 end

--- a/lib/elm/rails.rb
+++ b/lib/elm/rails.rb
@@ -1,2 +1,8 @@
 require "elm/rails/helper"
 require "elm/rails/railtie"
+
+module Elm
+  module Rails
+    mattr_accessor(:elm_make_path) { "elm-make" }
+  end
+end

--- a/lib/elm/rails/sprockets.rb
+++ b/lib/elm/rails/sprockets.rb
@@ -24,9 +24,9 @@ module Elm
       end
 
       def call(input)
-        context  = input[:environment].context_class.new(input)
+        context = input[:environment].context_class.new(input)
         add_elm_dependencies(input[:filename], input[:load_path], context)
-        context.metadata.merge(data: Elm::Compiler.compile(input[:filename]))
+        context.metadata.merge(data: Elm::Compiler.compile(input[:filename], elm_make_path: Elm::Rails.elm_make_path))
       end
 
       private

--- a/test/rails4.2/Gemfile.lock
+++ b/test/rails4.2/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    elm-rails (0.1.2)
-      elm-compiler (~> 0.1.2)
+    elm-rails (0.2.1)
+      elm-compiler (>= 0.2.0)
       rails (>= 4.0)
 
 GEM
@@ -57,7 +57,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
     debug_inspector (0.0.2)
-    elm-compiler (0.1.2)
+    elm-compiler (0.2.1)
     erubis (2.7.0)
     execjs (2.7.0)
     globalid (0.3.7)
@@ -167,4 +167,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/test/rails5.0/Gemfile.lock
+++ b/test/rails5.0/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    elm-rails (0.1.2)
-      elm-compiler (~> 0.1.2)
+    elm-rails (0.2.1)
+      elm-compiler (>= 0.2.0)
       rails (>= 4.0)
 
 GEM
@@ -57,7 +57,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
     debug_inspector (0.0.2)
-    elm-compiler (0.1.2)
+    elm-compiler (0.2.1)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
@@ -180,4 +180,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.14.3


### PR DESCRIPTION
Hello! I have several Rails projects on my developer machine, many of them using elm-rails. Some apps are still on Elm 0.16, while some are still on Elm 0.17, and only a few are are on Elm 0.18. Therefore, its very helpful to specify in the configuration of each project which version of Elm to use. This PR does exactly that, by bumping elm-compiler to 0.2.1 and exposing a new `elm_make_path` configuration option. This should all be backwards compatible with the current release.

What do you think?