### PR TITLE
Workaround for slow elm compilations on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,30 @@ rvm:
   - 2.3.6
   - 2.2.9
 
+before_install:
+  - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
+
 install:
   - bundle install
   - bundle install --gemfile=test/acceptance/rails4.2/Gemfile
   - bundle install --gemfile=test/acceptance/rails5.0/Gemfile
   - npm install -g elm
+  - | # epic build time improvement, continued:
+    mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+    printf "#\041/bin/bash\n\necho \"Running elm-make with sysconfcpus -n 2\"\n\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
+    chmod +x $(npm config get prefix)/bin/elm-make
 
 cache:
   bundler: true
   directories:
     - node_modules
+    - sysconfcpus
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
+sudo: false
 language: ruby
-install:
-  - bundle install
-  - bundle install --gemfile=test/acceptance/rails4.2/Gemfile
-  - bundle install --gemfile=test/acceptance/rails5.0/Gemfile
-  - npm install -g elm
+
 rvm:
   - 2.5.0
   - 2.4.3
   - 2.3.6
   - 2.2.9
+
+install:
+  - bundle install
+  - bundle install --gemfile=test/acceptance/rails4.2/Gemfile
+  - bundle install --gemfile=test/acceptance/rails5.0/Gemfile
+  - npm install -g elm
+
+cache:
+  bundler: true
+  directories:
+    - node_modules
+


### PR DESCRIPTION
Travis was experiencing absurdly lengthy `elm-make` times for the trivial Elm code in the acceptance test, in the order of twenty minutes. Turns out this is caused to Elm's compiler trying to parallelize over more cores than is prudent, due to idiosyncrasies in Travis's shared environment.

We have to work around this, since Evan only merges and releases bugfixes every few years (if you're lucky). We do so by wrapping elm-make in a wrapper that lies about the number of available cpus, hardcoding it to 2. As a result, CI times drop from ~30m to ~5m.

Solution copied from: https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142